### PR TITLE
Change secret8 groundtruth from "true/false" to "1/0"

### DIFF
--- a/projects/tests/proj4/secret10.simplec
+++ b/projects/tests/proj4/secret10.simplec
@@ -45,7 +45,7 @@ int fu(int x, int y)
 
 int fubar(int x, int y)
 {
-	while (!(y == x))
+	while !(y == x)
 	{
 		print y;
 		y = y + 1;

--- a/projects/tests/proj4/secret10.simplec
+++ b/projects/tests/proj4/secret10.simplec
@@ -45,7 +45,7 @@ int fu(int x, int y)
 
 int fubar(int x, int y)
 {
-	while !(y == x)
+	while (!(y == x))
 	{
 		print y;
 		y = y + 1;

--- a/projects/tests/proj4/secret8.groundtruth
+++ b/projects/tests/proj4/secret8.groundtruth
@@ -1,7 +1,7 @@
-true
-true
-true
-true
-true
-true
-false
+1
+1
+1
+1
+1
+1
+0


### PR DESCRIPTION
For my understanding there is no way to print out true and false with the grammar we have. Changed it to 1 and 0 (coincides with the change I made to secret8.simplec changing "print true" to "print 1" and "print false" to "print 0").