### PR TITLE
move up declarations

### DIFF
--- a/projects/tests/proj4/example5.simplec
+++ b/projects/tests/proj4/example5.simplec
@@ -1,8 +1,8 @@
 int digits(int z) {
 	int zz;
+	int result;
 	zz = z;
 	print zz;
-	int result;
 	result = 0;
 	if (zz < 0) {
 		result = 0;

--- a/projects/tests/proj4/secret8.simplec
+++ b/projects/tests/proj4/secret8.simplec
@@ -1,8 +1,8 @@
 int power(int b, int p)
 {
 	int x;
-	x = 1;
 	int result;
+	x = 1;
 	result = 0;
 	
 	if (p < 1) 
@@ -91,6 +91,7 @@ int main()
 	int e;
 	int f;
 	int g;
+	int dummy;
 	a = 32323;
 	b = 212;
 	c = 23123;
@@ -98,7 +99,6 @@ int main()
 	e = 12212;
 	f = 12321;
 	g = 0;
-	int dummy;
 	dummy = palindrome(a);
 	dummy = palindrome(b);
 	dummy = palindrome(c);

--- a/projects/tests/proj4/secret9.simplec
+++ b/projects/tests/proj4/secret9.simplec
@@ -24,8 +24,8 @@ int foo(int x){
 int main()
 { 
 	int x; 
-	x = 0; 
 	int thing;
+	x = 0; 
 	thing = foo(x); 
 	return 0;
 } 


### PR DESCRIPTION
Some of the test cases had declaration(s) after statement(s) within one or more functions. This doesn't adhere to the function production in the grammar shown in project4.md, which has declaration* statement* within the curly braces.